### PR TITLE
remove the w-full from input

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -81,7 +81,7 @@ logs-docker:
 	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) logs -f
 
 .PHONY: runserver
-runserver:
+run-server:
 	$(MANAGE_PY) runserver
 
 .PHONY: makemessages

--- a/webapp/static/to_compile/css/base.css
+++ b/webapp/static/to_compile/css/base.css
@@ -19,5 +19,5 @@ label {
 }
 
 input {
-  @apply py-3 px-4 block w-full border-gray-200 rounded-md text-sm focus:border-blue-600 focus:ring-0;
+  @apply py-3 px-4 block border-gray-200 rounded-md text-sm focus:border-blue-600 focus:ring-0;
 }


### PR DESCRIPTION
# Brief description of the problem solved

The inputs are w-full, this is not well displayed


**🗺️ context**: CSS

**🤔 how**: remove `w-full` from buttoon

## Example results / UI / Data

<img width="1148" height="1510" alt="CleanShot 2025-11-06 at 08 24 16@2x" src="https://github.com/user-attachments/assets/8313354a-a783-4395-b76f-f6e91765287d" />

## Self-review

Things to do before requesting a review:

- [x] I have thoroughly reviewed my code
- [x] CI passes
- [x] In case of adding environment variables, I have updated the `.env.template`
- [ ] I have added tests that cover the new code

<!-- if needed

## ✅ TODO (WIP PR)

- [ ] Task to be done

## 📆 TODO (next PR)

- [ ] Task to do
-->
